### PR TITLE
Implement web GUI and ICMP scanning engine

### DIFF
--- a/cmd/pistonscan/main.go
+++ b/cmd/pistonscan/main.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"pistonmaster.net/pistonscan/internal/gui"
 )
 
-const usage = `PistonScan - IP scanning toolkit (work in progress)
+const usage = `PistonScan - IP scanning toolkit
 
 Usage:
-  pistonscan open   Open the PistonScan interface.
+  pistonscan open   Launch the PistonScan interface.
+  pistonscan help   Show this help message.
 `
 
 func main() {
@@ -27,8 +30,11 @@ func run(args []string) error {
 
 	switch args[0] {
 	case "open":
-		fmt.Println("Opening PistonScan... (functionality coming soon)")
-		return nil
+		if os.Getenv("PISTONSCAN_HEADLESS") == "1" {
+			return nil
+		}
+		application := gui.New()
+		return application.Run()
 	case "help", "--help", "-h":
 		fmt.Print(usage)
 		return nil

--- a/cmd/pistonscan/main_test.go
+++ b/cmd/pistonscan/main_test.go
@@ -9,6 +9,7 @@ func TestRunWithoutArgsShowsUsage(t *testing.T) {
 }
 
 func TestRunOpenCommand(t *testing.T) {
+	t.Setenv("PISTONSCAN_HEADLESS", "1")
 	if err := run([]string{"open"}); err != nil {
 		t.Fatalf("run returned error for open command: %v", err)
 	}

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -1,0 +1,354 @@
+package gui
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"pistonmaster.net/pistonscan/internal/scanner"
+)
+
+// App hosts the web-based graphical interface for PistonScan.
+type App struct {
+	scanner *scanner.Scanner
+
+	mu            sync.Mutex
+	results       []scanner.Result
+	expected      int
+	currentConfig scanner.Config
+
+	clients map[chan event]struct{}
+}
+
+// New constructs a new App instance ready to run.
+func New() *App {
+	a := &App{
+		scanner: scanner.New(),
+		clients: make(map[chan event]struct{}),
+	}
+	a.observeScanner()
+	return a
+}
+
+// Run starts the HTTP server hosting the GUI and blocks until it stops.
+func (a *App) Run() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", a.handleIndex)
+	mux.HandleFunc("/start", a.handleStart)
+	mux.HandleFunc("/pause", a.handlePause)
+	mux.HandleFunc("/resume", a.handleResume)
+	mux.HandleFunc("/cancel", a.handleCancel)
+	mux.HandleFunc("/export", a.handleExport)
+	mux.HandleFunc("/import", a.handleImport)
+	mux.HandleFunc("/snapshot", a.handleSnapshot)
+	mux.HandleFunc("/events", a.handleEvents)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	addr := ln.Addr().String()
+	fmt.Printf("PistonScan GUI available at http://%s\n", addr)
+	a.launchBrowser(addr)
+
+	server := &http.Server{Handler: mux}
+	if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func (a *App) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	io.WriteString(w, indexHTML)
+}
+
+func (a *App) handleStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Subnet  string `json:"subnet"`
+		Threads int    `json:"threads"`
+		DelayMS int    `json:"delay_ms"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request payload", http.StatusBadRequest)
+		return
+	}
+	cfg := scanner.Config{
+		Subnet:  strings.TrimSpace(req.Subnet),
+		Threads: req.Threads,
+		Delay:   time.Duration(req.DelayMS) * time.Millisecond,
+		Timeout: 2 * time.Second,
+	}
+	if err := a.scanner.Start(cfg); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	a.mu.Lock()
+	a.results = nil
+	a.expected = a.scanner.TargetTotal()
+	a.currentConfig = cfg
+	a.mu.Unlock()
+	a.broadcastSnapshot()
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (a *App) handlePause(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	a.scanner.Pause()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *App) handleResume(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	a.scanner.Resume()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *App) handleCancel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	a.scanner.Cancel()
+	a.mu.Lock()
+	a.results = a.scanner.Results()
+	a.mu.Unlock()
+	a.broadcastSnapshot()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *App) handleExport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	a.mu.Lock()
+	results := append([]scanner.Result(nil), a.results...)
+	cfg := a.currentConfig
+	a.mu.Unlock()
+	if len(results) == 0 {
+		http.Error(w, "no scan data to export", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", "attachment; filename=scan.json")
+	if err := scanner.Save(w, cfg, results); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (a *App) handleImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "unable to read upload", http.StatusBadRequest)
+		return
+	}
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "missing file", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	cfg, results, err := scanner.Load(file)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	a.mu.Lock()
+	a.results = results
+	a.expected = len(results)
+	a.currentConfig = cfg
+	a.mu.Unlock()
+	a.broadcastSnapshot()
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (a *App) handleSnapshot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	snapshot := a.snapshotEvent()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(snapshot)
+}
+
+func (a *App) handleEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	ch := make(chan event, 8)
+	a.addClient(ch)
+	defer a.removeClient(ch)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	initial := a.snapshotEvent()
+	writeEvent(w, initial)
+	flusher.Flush()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev := <-ch:
+			writeEvent(w, ev)
+			flusher.Flush()
+		}
+	}
+}
+
+func (a *App) observeScanner() {
+	go func() {
+		for range a.scanner.Updates() {
+			a.mu.Lock()
+			a.results = a.scanner.Results()
+			a.mu.Unlock()
+			a.broadcastSnapshot()
+		}
+	}()
+	go func() {
+		for range a.scanner.StateChanges() {
+			a.broadcastSnapshot()
+		}
+	}()
+}
+
+func (a *App) broadcastSnapshot() {
+	a.broadcast(a.snapshotEvent())
+}
+
+func (a *App) snapshotEvent() event {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	ev := event{
+		Type:     "snapshot",
+		State:    a.scanner.State().String(),
+		Expected: a.expected,
+		Results:  make([]ResultPayload, len(a.results)),
+	}
+	for i, res := range a.results {
+		ev.Results[i] = convertResult(res)
+	}
+	ev.Completed = len(a.results)
+	return ev
+}
+
+func (a *App) addClient(ch chan event) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.clients[ch] = struct{}{}
+}
+
+func (a *App) removeClient(ch chan event) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.clients, ch)
+	close(ch)
+}
+
+func (a *App) broadcast(ev event) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for ch := range a.clients {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+func writeEvent(w http.ResponseWriter, ev event) {
+	data, _ := json.Marshal(ev)
+	fmt.Fprintf(w, "data: %s\n\n", data)
+}
+
+func convertResult(res scanner.Result) ResultPayload {
+	return ResultPayload{
+		IP:        res.IP,
+		Reachable: res.Reachable,
+		LatencyMS: res.Latency.Milliseconds(),
+		CheckedAt: res.CheckedAt.Format(time.RFC3339),
+		Error:     res.Error,
+	}
+}
+
+func (a *App) launchBrowser(addr string) {
+	url := "http://" + addr
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if cmd != nil {
+		cmd.Start()
+	}
+}
+
+type event struct {
+	Type      string          `json:"type"`
+	State     string          `json:"state"`
+	Expected  int             `json:"expected"`
+	Completed int             `json:"completed"`
+	Results   []ResultPayload `json:"results"`
+}
+
+// ResultPayload is sent to the web interface for rendering.
+type ResultPayload struct {
+	IP        string `json:"ip"`
+	Reachable bool   `json:"reachable"`
+	LatencyMS int64  `json:"latency_ms"`
+	CheckedAt string `json:"checked_at"`
+	Error     string `json:"error"`
+}
+
+// LoadSnapshotFromReader allows tests to supply snapshot data without multipart parsing.
+func LoadSnapshotFromReader(r io.Reader) (scanner.Config, []scanner.Result, error) {
+	return scanner.Load(r)
+}
+
+// SaveSnapshotToWriter exposes snapshot saving for tests or integrations.
+func SaveSnapshotToWriter(w io.Writer, cfg scanner.Config, results []scanner.Result) error {
+	return scanner.Save(w, cfg, results)
+}

--- a/internal/gui/assets.go
+++ b/internal/gui/assets.go
@@ -1,0 +1,6 @@
+package gui
+
+import _ "embed"
+
+//go:embed static/index.html
+var indexHTML string

--- a/internal/gui/static/index.html
+++ b/internal/gui/static/index.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>PistonScan</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f7f7f7;
+  color: #222;
+}
+header {
+  background: #222;
+  color: #fff;
+  padding: 1rem 2rem;
+}
+main {
+  padding: 1rem 2rem 3rem 2rem;
+}
+section {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+input[type="text"], input[type="number"] {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+}
+button {
+  padding: 0.6rem 1.2rem;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #1d72b8;
+  color: #fff;
+  cursor: pointer;
+}
+button:disabled {
+  background-color: #9abbd6;
+  cursor: not-allowed;
+}
+#status {
+  font-weight: bold;
+  margin-top: 0.5rem;
+}
+.table-container {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+th, td {
+  border: 1px solid #ddd;
+  padding: 0.6rem;
+  text-align: left;
+}
+th {
+  background-color: #f0f0f0;
+}
+.error {
+  color: #c0392b;
+  margin-top: 0.5rem;
+  min-height: 1rem;
+}
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.control-group {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 400px;
+}
+</style>
+</head>
+<body>
+<header>
+  <h1>PistonScan</h1>
+</header>
+<main>
+  <section>
+    <div class="control-group">
+      <div>
+        <label for="subnet">Subnet (CIDR)</label>
+        <input id="subnet" type="text" placeholder="192.168.1.0/24" />
+      </div>
+      <div>
+        <label for="threads">Maximum threads</label>
+        <input id="threads" type="number" min="1" value="10" />
+      </div>
+      <div>
+        <label for="delay">Delay per thread (ms)</label>
+        <input id="delay" type="number" min="0" value="100" />
+      </div>
+    </div>
+    <div class="controls">
+      <button id="start">Start</button>
+      <button id="pause">Pause</button>
+      <button id="resume">Resume</button>
+      <button id="cancel">Cancel</button>
+      <button id="export">Export</button>
+      <label style="margin-bottom:0.5rem;">
+        <span style="display:inline-block;margin-right:0.4rem;">Import</span>
+        <input id="import" type="file" accept="application/json" style="display:inline-block;" />
+      </label>
+    </div>
+    <div id="status">Idle</div>
+    <div class="error" id="error"></div>
+  </section>
+  <section>
+    <h2>Scan Results</h2>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>IP Address</th>
+            <th>Reachable</th>
+            <th>Latency (ms)</th>
+            <th>Checked At</th>
+            <th>Error</th>
+          </tr>
+        </thead>
+        <tbody id="results"></tbody>
+      </table>
+    </div>
+  </section>
+</main>
+<script>
+const statusEl = document.getElementById("status");
+const errorEl = document.getElementById("error");
+const resultsBody = document.getElementById("results");
+const startBtn = document.getElementById("start");
+const pauseBtn = document.getElementById("pause");
+const resumeBtn = document.getElementById("resume");
+const cancelBtn = document.getElementById("cancel");
+const exportBtn = document.getElementById("export");
+const importInput = document.getElementById("import");
+
+let currentState = "Idle";
+let expectedTargets = 0;
+let results = [];
+
+function setError(message) {
+  errorEl.textContent = message || "";
+}
+
+function updateStatus() {
+  let text = currentState;
+  if (expectedTargets > 0) {
+    text += ` (${results.length}/${expectedTargets})`;
+  }
+  statusEl.textContent = text;
+  startBtn.disabled = currentState === "Running" || currentState === "Paused";
+  pauseBtn.disabled = currentState !== "Running";
+  resumeBtn.disabled = currentState !== "Paused";
+  cancelBtn.disabled = currentState !== "Running" && currentState !== "Paused";
+}
+
+function renderResults() {
+  resultsBody.innerHTML = "";
+  for (const row of results) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${row.ip}</td>
+      <td>${row.reachable ? "Yes" : "No"}</td>
+      <td>${row.latency_ms}</td>
+      <td>${row.checked_at}</td>
+      <td>${row.error || ""}</td>`;
+    resultsBody.appendChild(tr);
+  }
+}
+
+async function startScan() {
+  setError("");
+  const payload = {
+    subnet: document.getElementById("subnet").value,
+    threads: parseInt(document.getElementById("threads").value, 10),
+    delay_ms: parseInt(document.getElementById("delay").value, 10)
+  };
+  try {
+    const response = await fetch("/start", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify(payload)
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      setError(text || "Unable to start scan");
+    }
+  } catch (err) {
+    setError("Failed to contact server");
+  }
+}
+
+async function sendCommand(path) {
+  setError("");
+  try {
+    const response = await fetch(path, {method: "POST"});
+    if (!response.ok) {
+      const text = await response.text();
+      setError(text || "Operation failed");
+    }
+  } catch (err) {
+    setError("Failed to contact server");
+  }
+}
+
+function exportResults() {
+  if (results.length === 0) {
+    setError("No scan data to export");
+    return;
+  }
+  window.open("/export", "_blank");
+}
+
+function importResults(event) {
+  setError("");
+  const file = event.target.files[0];
+  if (!file) {
+    return;
+  }
+  const form = new FormData();
+  form.append("file", file);
+  fetch("/import", {method: "POST", body: form}).then(response => {
+    if (!response.ok) {
+      response.text().then(text => setError(text || "Import failed"));
+    }
+  }).catch(() => setError("Import failed"));
+  event.target.value = "";
+}
+
+function connectEvents() {
+  const source = new EventSource("/events");
+  source.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data.type === "snapshot") {
+        currentState = data.state || "Idle";
+        expectedTargets = data.expected || 0;
+        results = data.results || [];
+        renderResults();
+        updateStatus();
+      }
+    } catch (err) {
+      console.error("Failed to parse event", err);
+    }
+  };
+  source.onerror = () => {
+    source.close();
+    setTimeout(connectEvents, 2000);
+  };
+}
+
+startBtn.addEventListener("click", startScan);
+pauseBtn.addEventListener("click", () => sendCommand("/pause"));
+resumeBtn.addEventListener("click", () => sendCommand("/resume"));
+cancelBtn.addEventListener("click", () => sendCommand("/cancel"));
+exportBtn.addEventListener("click", exportResults);
+importInput.addEventListener("change", importResults);
+
+connectEvents();
+updateStatus();
+</script>
+</body>
+</html>

--- a/internal/scanner/network.go
+++ b/internal/scanner/network.go
@@ -1,0 +1,36 @@
+package scanner
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+)
+
+func expandCIDR(cidr string) ([]string, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return nil, errors.New("only IPv4 subnets are supported")
+	}
+
+	maskOnes, maskBits := ipNet.Mask.Size()
+	if maskBits != 32 {
+		return nil, errors.New("unexpected mask size")
+	}
+	hostCount := 1 << (32 - maskOnes)
+	results := make([]string, 0, hostCount)
+
+	network := binary.BigEndian.Uint32(ip4)
+	for i := 0; i < hostCount; i++ {
+		addr := make(net.IP, 4)
+		binary.BigEndian.PutUint32(addr, network+uint32(i))
+		if !ipNet.Contains(addr) {
+			continue
+		}
+		results = append(results, addr.String())
+	}
+	return results, nil
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,404 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// State represents the lifecycle state of a scan operation.
+type State int
+
+const (
+	// Idle indicates that the scanner is not running a scan.
+	Idle State = iota
+	// Running indicates that a scan is actively processing targets.
+	Running
+	// Paused indicates that the scan is temporarily halted.
+	Paused
+	// Completed indicates that the scan has finished all targets successfully.
+	Completed
+	// Cancelled indicates that the scan was aborted before completion.
+	Cancelled
+)
+
+func (s State) String() string {
+	switch s {
+	case Idle:
+		return "Idle"
+	case Running:
+		return "Running"
+	case Paused:
+		return "Paused"
+	case Completed:
+		return "Completed"
+	case Cancelled:
+		return "Cancelled"
+	default:
+		return "Unknown"
+	}
+}
+
+// Config captures user preferences for a scan run.
+type Config struct {
+	Subnet  string
+	Threads int
+	Delay   time.Duration
+	Timeout time.Duration
+}
+
+// Result represents the outcome of scanning a single IP address.
+type Result struct {
+	IP        string
+	Reachable bool
+	Latency   time.Duration
+	CheckedAt time.Time
+	Error     string
+}
+
+// Scanner coordinates scanning operations across workers and exposes their progress.
+type Scanner struct {
+	mu      sync.RWMutex
+	cfg     Config
+	state   State
+	results map[string]Result
+	total   int
+
+	updates chan Result
+	stateCh chan State
+
+	pauseMu   sync.Mutex
+	pauseCond *sync.Cond
+	paused    bool
+
+	cancelFn context.CancelFunc
+	waitCh   chan struct{}
+}
+
+// New creates a scanner ready to execute scans.
+func New() *Scanner {
+	s := &Scanner{
+		state:   Idle,
+		results: make(map[string]Result),
+		updates: make(chan Result, 128),
+		stateCh: make(chan State, 16),
+	}
+	s.pauseCond = sync.NewCond(&s.pauseMu)
+	return s
+}
+
+// Start begins a scan based on the provided configuration.
+func (s *Scanner) Start(cfg Config) error {
+	if cfg.Subnet == "" {
+		return errors.New("subnet must be provided")
+	}
+
+	ips, err := expandSubnet(cfg.Subnet)
+	if err != nil {
+		return err
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("no IPs found for subnet %q", cfg.Subnet)
+	}
+
+	if cfg.Threads <= 0 {
+		cfg.Threads = 1
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 2 * time.Second
+	}
+	if cfg.Delay < 0 {
+		return errors.New("delay must not be negative")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state == Running || s.state == Paused {
+		return errors.New("scan already in progress")
+	}
+
+	s.cfg = cfg
+	s.total = len(ips)
+	s.results = make(map[string]Result)
+	s.paused = false
+	s.waitCh = make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancelFn = cancel
+
+	s.setStateLocked(Running)
+
+	go s.run(ctx, ips)
+
+	return nil
+}
+
+// Pause suspends the scan until Resume is called.
+func (s *Scanner) Pause() {
+	s.mu.Lock()
+	if s.state != Running {
+		s.mu.Unlock()
+		return
+	}
+	s.setStateLocked(Paused)
+	s.mu.Unlock()
+
+	s.pauseMu.Lock()
+	s.paused = true
+	s.pauseMu.Unlock()
+}
+
+// Resume continues a paused scan.
+func (s *Scanner) Resume() {
+	s.mu.Lock()
+	if s.state != Paused {
+		s.mu.Unlock()
+		return
+	}
+	s.setStateLocked(Running)
+	s.mu.Unlock()
+
+	s.pauseMu.Lock()
+	s.paused = false
+	s.pauseCond.Broadcast()
+	s.pauseMu.Unlock()
+}
+
+// Cancel stops an active scan immediately.
+func (s *Scanner) Cancel() {
+	s.mu.Lock()
+	if s.state == Idle || s.state == Completed || s.state == Cancelled {
+		s.mu.Unlock()
+		return
+	}
+	if s.cancelFn != nil {
+		s.cancelFn()
+	}
+	s.setStateLocked(Cancelled)
+	waitCh := s.waitCh
+	s.mu.Unlock()
+
+	s.pauseMu.Lock()
+	s.paused = false
+	s.pauseCond.Broadcast()
+	s.pauseMu.Unlock()
+
+	if waitCh != nil {
+		<-waitCh
+	}
+}
+
+// Updates exposes a channel of scan result updates.
+func (s *Scanner) Updates() <-chan Result {
+	return s.updates
+}
+
+// StateChanges exposes a channel of state transitions.
+func (s *Scanner) StateChanges() <-chan State {
+	return s.stateCh
+}
+
+// Results returns the current set of results sorted by IP address.
+func (s *Scanner) Results() []Result {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Result, 0, len(s.results))
+	for _, res := range s.results {
+		out = append(out, res)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].IP < out[j].IP
+	})
+	return out
+}
+
+// CurrentConfig returns the configuration used for the current scan.
+func (s *Scanner) CurrentConfig() Config {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.cfg
+}
+
+// TargetTotal returns the number of targets scheduled for the current scan.
+func (s *Scanner) TargetTotal() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.total
+}
+
+// State returns the scanner's current state.
+func (s *Scanner) State() State {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state
+}
+
+// Wait blocks until the current scan terminates.
+func (s *Scanner) Wait() {
+	s.mu.RLock()
+	waitCh := s.waitCh
+	s.mu.RUnlock()
+	if waitCh != nil {
+		<-waitCh
+	}
+}
+
+func (s *Scanner) setStateLocked(state State) {
+	s.state = state
+	select {
+	case s.stateCh <- state:
+	default:
+	}
+}
+
+func (s *Scanner) waitIfPaused(ctx context.Context) bool {
+	s.pauseMu.Lock()
+	for s.paused {
+		s.pauseCond.Wait()
+	}
+	s.pauseMu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+		return true
+	}
+}
+
+func (s *Scanner) run(ctx context.Context, ips []string) {
+	cfg := s.CurrentConfig()
+	jobs := make(chan string)
+	workerCount := cfg.Threads
+	if workerCount > len(ips) {
+		workerCount = len(ips)
+	}
+	if workerCount < 1 {
+		workerCount = 1
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer wg.Done()
+			for ip := range jobs {
+				if !s.waitIfPaused(ctx) {
+					return
+				}
+
+				latency, reachable, err := ping(ctx, ip, cfg.Timeout)
+
+				result := Result{
+					IP:        ip,
+					Reachable: reachable,
+					Latency:   latency,
+					CheckedAt: time.Now(),
+				}
+				if err != nil {
+					result.Error = err.Error()
+				}
+
+				s.mu.Lock()
+				s.results[ip] = result
+				s.mu.Unlock()
+
+				select {
+				case s.updates <- result:
+				default:
+				}
+
+				if cfg.Delay > 0 {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(cfg.Delay):
+					}
+				}
+
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, ip := range ips {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- ip:
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	s.mu.Lock()
+	if s.state != Cancelled {
+		s.setStateLocked(Completed)
+	}
+	waitCh := s.waitCh
+	s.mu.Unlock()
+
+	if waitCh != nil {
+		close(waitCh)
+	}
+}
+
+func ping(ctx context.Context, ip string, timeout time.Duration) (time.Duration, bool, error) {
+	start := time.Now()
+	pingCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"-c", "1", ip}
+	if runtime.GOOS == "windows" {
+		args = []string{"-n", "1", "-w", strconv.Itoa(int(timeout.Milliseconds())), ip}
+	} else {
+		secs := int(math.Ceil(timeout.Seconds()))
+		if secs < 1 {
+			secs = 1
+		}
+		args = []string{"-c", "1", "-W", strconv.Itoa(secs), ip}
+	}
+
+	cmd := exec.CommandContext(pingCtx, "ping", args...)
+	output, err := cmd.CombinedOutput()
+	latency := time.Since(start)
+
+	if errors.Is(pingCtx.Err(), context.DeadlineExceeded) {
+		return latency, false, fmt.Errorf("timeout after %s", timeout)
+	}
+
+	if err == nil {
+		return latency, true, nil
+	}
+
+	// Treat exit errors as an unreachable host rather than a fatal error.
+	if _, ok := err.(*exec.ExitError); ok {
+		msg := strings.TrimSpace(string(output))
+		if msg == "" {
+			msg = "host unreachable"
+		}
+		return latency, false, errors.New(msg)
+	}
+
+	return latency, false, err
+}
+
+func expandSubnet(cidr string) ([]string, error) {
+	return expandCIDR(cidr)
+}

--- a/internal/scanner/snapshot.go
+++ b/internal/scanner/snapshot.go
@@ -1,0 +1,102 @@
+package scanner
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+)
+
+const snapshotVersion = 1
+
+// Snapshot represents the serialisable state of a scan.
+type Snapshot struct {
+	GeneratedAt time.Time      `json:"generated_at"`
+	Config      SnapshotConfig `json:"config"`
+	Results     []SnapshotItem `json:"results"`
+}
+
+// SnapshotConfig holds configuration metadata in exported files.
+type SnapshotConfig struct {
+	Subnet        string `json:"subnet"`
+	Threads       int    `json:"threads"`
+	DelayMillis   int    `json:"delay_ms"`
+	TimeoutMillis int    `json:"timeout_ms"`
+}
+
+// SnapshotItem captures a single scan result for export.
+type SnapshotItem struct {
+	IP           string    `json:"ip"`
+	Reachable    bool      `json:"reachable"`
+	LatencyMilli int64     `json:"latency_ms"`
+	CheckedAt    time.Time `json:"checked_at"`
+	Error        string    `json:"error,omitempty"`
+}
+
+// Save writes configuration and results to the writer as a JSON snapshot.
+func Save(w io.Writer, cfg Config, results []Result) error {
+	snap := Snapshot{
+		GeneratedAt: time.Now().UTC(),
+		Config: SnapshotConfig{
+			Subnet:        cfg.Subnet,
+			Threads:       cfg.Threads,
+			DelayMillis:   int(cfg.Delay / time.Millisecond),
+			TimeoutMillis: int(cfg.Timeout / time.Millisecond),
+		},
+	}
+	for _, res := range results {
+		snap.Results = append(snap.Results, SnapshotItem{
+			IP:           res.IP,
+			Reachable:    res.Reachable,
+			LatencyMilli: res.Latency.Milliseconds(),
+			CheckedAt:    res.CheckedAt,
+			Error:        res.Error,
+		})
+	}
+
+	payload := struct {
+		Version  int      `json:"version"`
+		Snapshot Snapshot `json:"snapshot"`
+	}{
+		Version:  snapshotVersion,
+		Snapshot: snap,
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(payload)
+}
+
+// Load reads a snapshot from the reader and returns the configuration and results it contains.
+func Load(r io.Reader) (Config, []Result, error) {
+	var payload struct {
+		Version  int      `json:"version"`
+		Snapshot Snapshot `json:"snapshot"`
+	}
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(&payload); err != nil {
+		return Config{}, nil, err
+	}
+	if payload.Version != snapshotVersion {
+		return Config{}, nil, errors.New("unsupported snapshot version")
+	}
+
+	cfg := Config{
+		Subnet:  payload.Snapshot.Config.Subnet,
+		Threads: payload.Snapshot.Config.Threads,
+		Delay:   time.Duration(payload.Snapshot.Config.DelayMillis) * time.Millisecond,
+		Timeout: time.Duration(payload.Snapshot.Config.TimeoutMillis) * time.Millisecond,
+	}
+
+	results := make([]Result, 0, len(payload.Snapshot.Results))
+	for _, item := range payload.Snapshot.Results {
+		results = append(results, Result{
+			IP:        item.IP,
+			Reachable: item.Reachable,
+			Latency:   time.Duration(item.LatencyMilli) * time.Millisecond,
+			CheckedAt: item.CheckedAt,
+			Error:     item.Error,
+		})
+	}
+	return cfg, results, nil
+}


### PR DESCRIPTION
## Summary
- add an ICMP subnet scanner with pause, resume, cancel, and configurable worker controls
- build a web-based interface that streams scan progress, allows import/export, and manages scan lifecycle
- persist scan results using a JSON snapshot format for export and reuse

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_69088125bc708331a24e65439dc6a034